### PR TITLE
delete button now gives the user a warning for computer

### DIFF
--- a/hrapp/templates/computers/computer_details.html
+++ b/hrapp/templates/computers/computer_details.html
@@ -26,7 +26,7 @@
     <form action="{% url 'hrapp:computer_details' computer.id %}" method="POST">
         {% csrf_token %}
         <input type="hidden" name="actual_method" value="DELETE">
-        <button>Delete</button>
+        <button onclick="return confirm('Are you sure you want to delete this?')">Delete</button>
     </form>
 {% endif %}
 


### PR DESCRIPTION
The delete button for computers now provides a pop-up message to the user to confirm if they really want to delete the computer. 

This is the final for #12 

add and commit your current branch
`git checkout master`
`git fetch --all`
`git checkout rc-delete-computer-warning-message`

Go to http://localhost:8000/computers/
Make sure you have a computer in your database that has never been assigned. If not, create one.
Try and delete your computer. Confirm that the message pops up to warn you about deleting.
Confirm that cancelling the delete prevents the delete from happening.
Confirm that pressing OK actually deletes the computer. 